### PR TITLE
Feature/standardizing responses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
   implementation 'org.springframework.boot:spring-boot-starter-web'
+  implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation "com.querydsl:querydsl-jpa:$querydslVersion:jakarta"
   
   compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/flarecafe/common/exception/BusinessException.java
+++ b/src/main/java/com/flarecafe/common/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package com.flarecafe.common.exception;
+
+import com.flarecafe.common.response.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/flarecafe/common/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/flarecafe/common/exception/GlobalExceptionAdvice.java
@@ -1,0 +1,36 @@
+package com.flarecafe.common.exception;
+import com.flarecafe.common.response.ErrorResponse;
+import com.flarecafe.common.response.code.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionAdvice {
+
+  /**
+   * Handles BusinessExceptions
+   */
+  @ExceptionHandler(BusinessException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  protected ErrorResponse handleBusinessException(final BusinessException e) {
+    final ErrorCode errorCode = e.getErrorCode();
+
+    return ErrorResponse.of(errorCode);
+  }
+
+  /**
+   * Handle MethodArgumentNotValidException
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  protected ErrorResponse handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+    final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+
+    return ErrorResponse.of(errorCode, e.getBindingResult());
+  }
+}

--- a/src/main/java/com/flarecafe/common/response/ErrorResponse.java
+++ b/src/main/java/com/flarecafe/common/response/ErrorResponse.java
@@ -1,0 +1,65 @@
+package com.flarecafe.common.response;
+
+import com.flarecafe.common.response.code.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+  private String code;
+  private String message;
+  private List<FieldErrorDetail> errorDetails;
+
+  private ErrorResponse(final ErrorCode code) {
+    this.message = code.getMessage();
+    this.code = code.getCode();
+    this.errorDetails = new ArrayList<>();
+  }
+
+  private ErrorResponse(final ErrorCode code, final List<FieldErrorDetail> errors) {
+    this.message = code.getMessage();
+    this.code = code.getCode();
+    this.errorDetails = errors;
+  }
+
+  public static ErrorResponse of(final ErrorCode code) {
+    return new ErrorResponse(code);
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+    return new ErrorResponse(code, FieldErrorDetail.from(bindingResult));
+  }
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class FieldErrorDetail {
+    private String field;
+    private String value;
+    private String message;
+
+    private FieldErrorDetail(final String field, final String value, final String message) {
+      this.field = field;
+      this.value = value;
+      this.message = message;
+    }
+
+    public static List<FieldErrorDetail> from(final BindingResult bindingResult) {
+      final List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+
+      return fieldErrors.stream()
+        .map(fieldError -> new FieldErrorDetail(
+          fieldError.getField(),
+          fieldError.getRejectedValue() == null ? "" : fieldError.getRejectedValue().toString(),
+          fieldError.getDefaultMessage()))
+        .toList();
+    }
+  }
+}

--- a/src/main/java/com/flarecafe/common/response/SuccessListResponse.java
+++ b/src/main/java/com/flarecafe/common/response/SuccessListResponse.java
@@ -1,0 +1,28 @@
+package com.flarecafe.common.response;
+
+import com.flarecafe.common.response.code.SuccessCode;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SuccessListResponse<T> {
+
+  private String code;
+  private String message;
+  private List<T> list;
+  private int totalCount;
+  private Integer pageSize;
+  private Integer pageNumber;
+
+  public SuccessListResponse(SuccessCode successCode, List<T> list) {
+    this.code = successCode.getCode();
+    this.message = successCode.getMessage();
+    this.list = list;
+    this.totalCount = list.size();
+  }
+
+  public static <T> SuccessListResponse<T> of(SuccessCode successCode, List<T> list) {
+    return new SuccessListResponse<>(successCode, list);
+  }
+}

--- a/src/main/java/com/flarecafe/common/response/SuccessResponse.java
+++ b/src/main/java/com/flarecafe/common/response/SuccessResponse.java
@@ -1,0 +1,22 @@
+package com.flarecafe.common.response;
+
+import com.flarecafe.common.response.code.SuccessCode;
+import lombok.Getter;
+
+@Getter
+public class SuccessResponse<T> {
+
+  private final String code;
+  private final String message;
+  private final T data;
+
+  public SuccessResponse(SuccessCode successCode, T data) {
+    this.code = successCode.getCode();
+    this.message = successCode.getMessage();
+    this.data = data;
+  }
+
+  public static <T> SuccessResponse<T> of(SuccessCode successCode, T data) {
+    return new SuccessResponse<>(successCode, data);
+  }
+}

--- a/src/main/java/com/flarecafe/common/response/code/ErrorCode.java
+++ b/src/main/java/com/flarecafe/common/response/code/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.flarecafe.common.response.code;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+  INVALID_INPUT_VALUE("0001", "Invalid Input Value"),
+
+  // Business Errors
+  INVALID_MENU_NAME("0002", "Invalid menu name"),
+  ;
+
+  private static final String PREFIX = "FLARE-CAFE-ERROR-%s";
+  private final String code;
+  private final String message;
+
+  ErrorCode(String code, String message) {
+    this.code = String.format(PREFIX, code);
+    this.message = message;
+  }
+}

--- a/src/main/java/com/flarecafe/common/response/code/SuccessCode.java
+++ b/src/main/java/com/flarecafe/common/response/code/SuccessCode.java
@@ -1,0 +1,18 @@
+package com.flarecafe.common.response.code;
+
+import lombok.Getter;
+
+@Getter
+public enum SuccessCode {
+  OK("0001", "Request Successful"),
+  ;
+
+  private static final String PREFIX = "FLARE-CAFE-SUCCESS-%s";
+  private final String code;
+  private final String message;
+
+  SuccessCode(String message, String code) {
+    this.message = String.format(PREFIX, message);
+    this.code = code;
+  }
+}


### PR DESCRIPTION
## Description

#3 

## Questions

1. Would it be a good idea to create an enum like SuccessCode to avoid specifying the code and message for SuccessResponse every time?

2. In the ErrorCode enum, should we also manage standard errors like 404 and 400, in addition to business errors?

3. Why is `SuccessResponse<Void, List<String>> response = SuccessResponse.of("", "", items);` considered invalid syntax?
