### PR TITLE
feat: add Menu category support and refactor promotion discount logic

### DIFF
--- a/src/main/java/com/flarecafe/feature/menu/domain/model/Menu.java
+++ b/src/main/java/com/flarecafe/feature/menu/domain/model/Menu.java
@@ -5,6 +5,7 @@ import com.flarecafe.feature.menu.domain.model.support.Category;
 import com.flarecafe.feature.menu.domain.model.support.MenuStatus;
 import com.flarecafe.feature.optiongroup.domain.model.Option;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -12,7 +13,9 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+@Getter
 @Entity
 public class Menu {
   @Id
@@ -61,4 +64,28 @@ public class Menu {
 
     return this.price.getAmount().add(totalOptionPrice);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof Menu menu)) return false;
+    return Objects.equals(id, menu.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+  
+  public static Menu fixture() {
+    Menu menu = new Menu();
+    menu.category = Category.COFFEE;
+    menu.name = "커피";
+    menu.price = Money.of(10000);
+    menu.ingredients = "커피, 우유, 초콜릿";
+    menu.imageUrl = "https://cdn.pixabay.com/photo/2017/08/12/18/58/coffee-2635031_1280.jpg";
+    menu.status = MenuStatus.SELLABLE;
+    menu.createdDate = LocalDateTime.now();
+    return menu;
+  }
+  
 }

--- a/src/main/java/com/flarecafe/feature/promotion/domain/DiscountService.java
+++ b/src/main/java/com/flarecafe/feature/promotion/domain/DiscountService.java
@@ -2,6 +2,7 @@ package com.flarecafe.feature.promotion.domain;
 
 import com.flarecafe.feature.generic.DomainService;
 import com.flarecafe.feature.generic.Money;
+import com.flarecafe.feature.menu.domain.model.Menu;
 import com.flarecafe.feature.promotion.domain.discount.DiscountTemplate;
 import com.flarecafe.feature.promotion.domain.model.Promotion;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,8 @@ public class DiscountService {
 
   private final DiscountTemplateFactory discountTemplateFactory;
 
-  public Money applyDiscount(Promotion promotion, String menu) {
+  // todo : Menu를 Order로 변경 필요
+  public Money applyDiscount(Promotion promotion, Menu menu) {
     DiscountTemplate discountTemplate = discountTemplateFactory.create(promotion);
     return discountTemplate.discount(promotion, menu);
   }

--- a/src/main/java/com/flarecafe/feature/promotion/domain/discount/DiscountTemplate.java
+++ b/src/main/java/com/flarecafe/feature/promotion/domain/discount/DiscountTemplate.java
@@ -1,6 +1,7 @@
 package com.flarecafe.feature.promotion.domain.discount;
 
 import com.flarecafe.feature.generic.Money;
+import com.flarecafe.feature.menu.domain.model.Menu;
 import com.flarecafe.feature.promotion.domain.DiscountPolicy;
 import com.flarecafe.feature.promotion.domain.model.Promotion;
 import com.flarecafe.feature.promotion.domain.model.PromotionCondition;
@@ -13,13 +14,14 @@ public class DiscountTemplate {
     this.discountPolicy = discountPolicy;
   }
   
-  public Money discount(Promotion promotion, String menu) {
+  // todo : Menu를 Order로 변경 필요. Order에서 메뉴 + 추가금 합산 금액을 제공할 것.
+  public Money discount(Promotion promotion, Menu menu) {
 
-    // todo : menu로부터 가져올 것.
+//    Money money = menu.calculateTotalPrice(); // todo : Order에서 메뉴 + 추가금 합산 금액을 제공할 것.
     Money money = Money.ZERO;
     
     for (PromotionCondition promotionCondition : promotion.getPromotionConditions()) {
-      if (promotionCondition.evaluate("category", menu)) { // todo : menu로부터 카테고리 가져올 것
+      if (promotionCondition.evaluate(menu)) {
         return discountPolicy.discount(promotion, money);
       }
     }

--- a/src/main/java/com/flarecafe/feature/promotion/domain/evaluator/EvaluationContext.java
+++ b/src/main/java/com/flarecafe/feature/promotion/domain/evaluator/EvaluationContext.java
@@ -1,9 +1,12 @@
 package com.flarecafe.feature.promotion.domain.evaluator;
 
-public record EvaluationContext(String category, String menu) {
+import com.flarecafe.feature.menu.domain.model.Menu;
+import com.flarecafe.feature.menu.domain.model.support.Category;
 
-  public static EvaluationContext of(String category, String menu) {
-    return new EvaluationContext(category, menu);
+public record EvaluationContext(Category category, Menu menu) {
+
+  public static EvaluationContext of(Menu menu) {
+    return new EvaluationContext(menu.getCategory(), menu);
   }
 
 }

--- a/src/main/java/com/flarecafe/feature/promotion/domain/model/PromotionCategory.java
+++ b/src/main/java/com/flarecafe/feature/promotion/domain/model/PromotionCategory.java
@@ -1,6 +1,7 @@
 package com.flarecafe.feature.promotion.domain.model;
 
 import com.flarecafe.feature.generic.BaseEntity;
+import com.flarecafe.feature.menu.domain.model.support.Category;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,11 +23,10 @@ public class PromotionCategory extends BaseEntity {
   @JoinColumn(name = "promotion_condition_id")
   private PromotionCondition promotionCondition;
 
-  // todo : category Enum으로 변경
-//  @Enumerated(EnumType.STRING)
-  private String category;
+  @Enumerated(EnumType.STRING)
+  private Category category;
 
-  public PromotionCategory(PromotionCondition promotionCondition, String category) {
+  public PromotionCategory(PromotionCondition promotionCondition, Category category) {
     this.promotionCondition = promotionCondition;
     this.category = category;
   }

--- a/src/main/java/com/flarecafe/feature/promotion/domain/model/PromotionCondition.java
+++ b/src/main/java/com/flarecafe/feature/promotion/domain/model/PromotionCondition.java
@@ -1,6 +1,8 @@
 package com.flarecafe.feature.promotion.domain.model;
 
 import com.flarecafe.feature.generic.BaseEntity;
+import com.flarecafe.feature.menu.domain.model.Menu;
+import com.flarecafe.feature.menu.domain.model.support.Category;
 import com.flarecafe.feature.promotion.domain.evaluator.EvaluationContext;
 import com.flarecafe.feature.promotion.domain.support.ConditionType;
 import com.flarecafe.feature.promotion.domain.support.PromotionCategories;
@@ -12,7 +14,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 
 @Getter
 @Entity
@@ -47,22 +48,20 @@ public class PromotionCondition extends BaseEntity {
     this.promotionMenus = promotionMenus;
   }
 
-  // todo menu domain 으로 변경 필요
-  public boolean includesMenu(String menu) {
+  public boolean evaluate(Menu menu) {
+    return conditionType.evaluate(this, EvaluationContext.of(menu));
+  }
+
+  public boolean includesMenu(Menu menu) {
     return promotionMenus.includes(menu);
   }
-  
-  // todo category enum으로 변경
-  public boolean includesCategory(String category) {
+
+  public boolean includesCategory(Category category) {
     return promotionCategories.includes(category);
   }
-  
+
   public boolean isInRange(LocalDateTime localDateTime) {
     return promotion.isInRange(localDateTime);
-  }
-  
-  public boolean evaluate(String category, String menu) {
-    return conditionType.evaluate(this, EvaluationContext.of(category, menu));
   }
 
   public void updatePromotion(Promotion promotion) {
@@ -75,8 +74,8 @@ public class PromotionCondition extends BaseEntity {
             .conditionType(ConditionType.CATEGORY)
             .build();
 
-    PromotionCategory latte = new PromotionCategory(promotionCondition, "latte");
-    promotionCondition.promotionCategories.add(latte);
+    PromotionCategory coffee = new PromotionCategory(promotionCondition, Category.COFFEE);
+    promotionCondition.promotionCategories.add(coffee);
 
     return promotionCondition; 
   }

--- a/src/main/java/com/flarecafe/feature/promotion/domain/model/PromotionMenu.java
+++ b/src/main/java/com/flarecafe/feature/promotion/domain/model/PromotionMenu.java
@@ -1,10 +1,13 @@
 package com.flarecafe.feature.promotion.domain.model;
 
 import com.flarecafe.feature.generic.BaseEntity;
+import com.flarecafe.feature.menu.domain.model.Menu;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
+@Getter
 @Entity
 @Table(name = "promotion_menu")
 @DynamicUpdate
@@ -20,10 +23,11 @@ public class PromotionMenu extends BaseEntity {
   @JoinColumn(name = "promotion_condition_id")
   private PromotionCondition promotionCondition;
   
-  // todo : menu 연관관계 설정 필요
-  private String menu;
+  @ManyToOne
+  @JoinColumn(name = "menu_id")
+  private Menu menu;
 
-  public PromotionMenu(PromotionCondition promotionCondition, String menu) {
+  public PromotionMenu(PromotionCondition promotionCondition, Menu menu) {
     this.promotionCondition = promotionCondition;
     this.menu = menu;
   }

--- a/src/main/java/com/flarecafe/feature/promotion/domain/support/ConditionType.java
+++ b/src/main/java/com/flarecafe/feature/promotion/domain/support/ConditionType.java
@@ -1,7 +1,6 @@
 package com.flarecafe.feature.promotion.domain.support;
 
 import com.flarecafe.feature.promotion.domain.evaluator.EvaluationContext;
-import com.flarecafe.feature.promotion.domain.model.Promotion;
 import com.flarecafe.feature.promotion.domain.model.PromotionCondition;
 
 import java.time.LocalDateTime;
@@ -26,7 +25,7 @@ public enum ConditionType {
   ConditionType(BiFunction<PromotionCondition, EvaluationContext, Boolean> conditionEvaluator) {
     this.conditionEvaluator = conditionEvaluator;
   }
-
+  
   public boolean evaluate(PromotionCondition promotionCondition, EvaluationContext context) {
     return this.conditionEvaluator.apply(promotionCondition, context);
   }

--- a/src/main/java/com/flarecafe/feature/promotion/domain/support/PromotionCategories.java
+++ b/src/main/java/com/flarecafe/feature/promotion/domain/support/PromotionCategories.java
@@ -1,5 +1,6 @@
 package com.flarecafe.feature.promotion.domain.support;
 
+import com.flarecafe.feature.menu.domain.model.support.Category;
 import com.flarecafe.feature.promotion.domain.model.PromotionCategory;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
@@ -27,11 +28,10 @@ public class PromotionCategories {
     promotionCategories.add(promotionCategory);
   }
   
-  // todo menu domain으로 변경 필요
-  public boolean includes(String category) {
+  public boolean includes(Category category) {
     return promotionCategories.stream()
       .filter(PromotionCategory::isNotDeleted)
-      .anyMatch(promotionCategory -> promotionCategory.getCategory().equals(category));
+      .anyMatch(promotionCategory -> promotionCategory.getCategory() == category);
   }
   
 }

--- a/src/main/java/com/flarecafe/feature/promotion/domain/support/PromotionMenus.java
+++ b/src/main/java/com/flarecafe/feature/promotion/domain/support/PromotionMenus.java
@@ -1,5 +1,6 @@
 package com.flarecafe.feature.promotion.domain.support;
 
+import com.flarecafe.feature.menu.domain.model.Menu;
 import com.flarecafe.feature.promotion.domain.model.PromotionMenu;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
@@ -23,11 +24,10 @@ public class PromotionMenus {
     this.promotionMenus = promotionMenus;
   }
 
-  // todo menu domain으로 변경 필요
-  public boolean includes(String paramMenu) {
+  public boolean includes(Menu menu) {
     return promotionMenus.stream()
       .filter(PromotionMenu::isNotDeleted)
-      .anyMatch(menu -> menu.equals(paramMenu));
+      .anyMatch(promotionMenu -> promotionMenu.getMenu().equals(menu));
   }
   
 }

--- a/src/test/java/com/flarecafe/feature/promotion/domain/PromotionRepositoryTest.java
+++ b/src/test/java/com/flarecafe/feature/promotion/domain/PromotionRepositoryTest.java
@@ -2,10 +2,7 @@ package com.flarecafe.feature.promotion.domain;
 
 import com.flarecafe.config.DataSourceConfig;
 import com.flarecafe.config.JpaConfig;
-import com.flarecafe.feature.generic.Money;
-import com.flarecafe.feature.generic.TimeInterval;
 import com.flarecafe.feature.promotion.domain.model.Promotion;
-import com.flarecafe.feature.promotion.domain.support.DiscountType;
 import com.flarecafe.feature.promotion.infra.PromotionJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/flarecafe/feature/promotion/domain/discount/DiscountTemplateTest.java
+++ b/src/test/java/com/flarecafe/feature/promotion/domain/discount/DiscountTemplateTest.java
@@ -2,6 +2,7 @@ package com.flarecafe.feature.promotion.domain.discount;
 
 import com.flarecafe.feature.generic.Money;
 import com.flarecafe.feature.generic.TimeInterval;
+import com.flarecafe.feature.menu.domain.model.Menu;
 import com.flarecafe.feature.promotion.domain.DiscountTemplateFactory;
 import com.flarecafe.feature.promotion.domain.model.Promotion;
 import com.flarecafe.feature.promotion.domain.support.DiscountType;
@@ -27,35 +28,35 @@ class DiscountTemplateTest {
     discountTemplateFactory = new DiscountTemplateFactory(List.of(amountDiscountPolicy, percentageDiscountPolicy));
   }
 
-  // todo : menu를 Menu로 바꾸어야 한다.
   @Test
   @Disabled
   void fixedAmountDiscount() {
 
     // given
+    Menu menu = Menu.fixture();
     Promotion promotion = Promotion.fixture();
     
     // when
     DiscountTemplate discountTemplate = discountTemplateFactory.create(promotion);
-    Money money = discountTemplate.discount(promotion, "menu");
+    Money money = discountTemplate.discount(promotion, menu);
 
     // then
-    assertEquals(money, Money.ZERO);
+    assertEquals(Money.ZERO, money);
     
   }
   
-  // todo : menu를 Menu로 바꾸어야 한다.
   @Test
   @Disabled
   void percentageDiscount() {
 
     // given
+    Menu menu = Menu.fixture();
     Promotion promotion = new Promotion();
     promotion.update("test", "test", DiscountType.PERCENTAGE, Money.of(10000), 15, TimeInterval.UN_LIMITED, "bright-flare");
     
     // when
     DiscountTemplate discountTemplate = discountTemplateFactory.create(promotion);
-    Money money = discountTemplate.discount(promotion, "menu");
+    Money money = discountTemplate.discount(promotion, menu);
 
     // then
     assertEquals(money, Money.of(17000));


### PR DESCRIPTION
### Outline

- #23 
- Menu and category are now applied to the promotion domain.

### Modifications

- Promotion doamin
- Menu domain - create `fixture()` and `equals()`, `hashcode()`

### Result

- Menu and category domains can now be used for discount amount calculation and evaluates, enabling more accurate computations.
