### PR TITLE
feat: implement AuthUser model and argument resolver for authentication user

### DIFF
--- a/src/main/java/com/flarecafe/common/auth/model/AuthUser.java
+++ b/src/main/java/com/flarecafe/common/auth/model/AuthUser.java
@@ -1,0 +1,8 @@
+package com.flarecafe.common.auth.model;
+
+public record AuthUser(Long userId, String userLoginId, String username) {
+  
+  public static AuthUser fixture() {
+    return new AuthUser(1L, "bright-brother", "luminous_bright_human");
+  }
+}

--- a/src/main/java/com/flarecafe/common/auth/model/BindAuthUser.java
+++ b/src/main/java/com/flarecafe/common/auth/model/BindAuthUser.java
@@ -1,0 +1,12 @@
+package com.flarecafe.common.auth.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BindAuthUser {
+  
+}

--- a/src/main/java/com/flarecafe/common/web/AuthUserArgumentResolver.java
+++ b/src/main/java/com/flarecafe/common/web/AuthUserArgumentResolver.java
@@ -1,0 +1,23 @@
+package com.flarecafe.common.web;
+
+import com.flarecafe.common.auth.model.AuthUser;
+import com.flarecafe.common.auth.model.BindAuthUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.hasParameterAnnotation(BindAuthUser.class);
+  }
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    return AuthUser.fixture();
+  }
+  
+}

--- a/src/main/java/com/flarecafe/common/web/WebConfig.java
+++ b/src/main/java/com/flarecafe/common/web/WebConfig.java
@@ -1,0 +1,17 @@
+package com.flarecafe.common.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(new AuthUserArgumentResolver());
+  }
+  
+}


### PR DESCRIPTION
### Outline

- While developing, we configured an Argument Resolver to temporarily inject an AuthUser so that we could access the authenticated user's information.

### Modifications

- Add ArgumentResolver , AuthUser

### Result

- We are can use this example code
```java
  @PostMapping("/promotions")
  public SuccessResponse create(@RequestBody CreatePromotion request, @BindAuthUser AuthUser user) {

    // When @BindAuthUser is declared in a controller,
    // the AuthUserArgumentResolver creates and injects an AuthUser instance.

    ... anything code
  }
```
