### PR TITLE
Feature/mockito gradle setting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,3 +49,9 @@ dependencies {
 tasks.withType<Test> {
   useJUnitPlatform()
 }
+
+tasks.test {
+  val mockitoJar = configurations.testRuntimeClasspath.get()
+    .first { it.name.contains("mockito-core") }
+  jvmArgs("-javaagent:${mockitoJar.absolutePath}")
+}


### PR DESCRIPTION
### Outline

- Configure Mockito to run as a Java Agent during tests in order to support inline mocking and remove future-incompatible runtime warnings.

### Modifications

- Updated test JVM configuration to attach Mockito (via Byte Buddy agent) using the -javaagent option in the Gradle test task.

- Ensured the agent JAR is resolved from the test runtime classpath so that the configuration is robust against version upgrades.

- Left application logic and test code unchanged; only build/test configuration was modified.

### Result

- Inline mocking (including final classes / methods) is now supported via a proper Java Agent instead of dynamic self-attachment.

- Suppressed runtime warnings such as:

- Mockito is currently self-attaching to enable the inline-mock-maker.

- Dynamic loading of agents will be disallowed by default in a future release

- Test execution is more future-proof against upcoming JDK changes, improving the stability of the test environment.
